### PR TITLE
attrs can be a string

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -83,9 +83,14 @@ Element.prototype.getXmlns = function() {
 
 Element.prototype.setAttrs = function(attrs) {
     this.attrs = {}
-    Object.keys(attrs || {}).forEach(function(key) {
-        this.attrs[key] = attrs[key]
-    }, this)
+
+    if (typeof attrs === 'string')
+        this.attrs.xmlns = attrs
+    else if (attrs) {
+        Object.keys(attrs).forEach(function(key) {
+            this.attrs[key] = attrs[key]
+        }, this)
+    }
 }
 
 /**

--- a/test/element-test.js
+++ b/test/element-test.js
@@ -14,6 +14,12 @@ vows.describe('ltx').addBatch({
             assert.equal(o.bar, undefined)
             o.foobar = 'barfoo'
             assert.equal(e.attrs.foobar, undefined)
+        },
+        'set xmlns attribute if a string is passed as second argument': function() {
+            var ns = 'xmlns:test'
+            var e = new ltx.Element('e', ns)
+            assert.equal(e.attrs.xmlns, ns)
+            assert.equal(e.getAttr('xmlns'), ns)
         }
     },
     'serialization': {


### PR DESCRIPTION
```javascript
(new Element('foo', 'test')).toString();
'<foo xmlns="test"/>'
```