### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,7 @@
     "Julien Genestoux",
     "▟ ▖▟ ▖"
   ],
-  "licenses": [
-    {
-      "type": "MIT"
-    }
-  ],
+  "license": "MIT",
   "engine": "node",
   "devDependencies": {
     "Strophe.js": "https://github.com/metajack/strophejs/tarball/master",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/