### PR TITLE
Remove node-expat as optional dependency like easysax, node-xml

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "description": "<xml for=\"node.js\" browserify=\"too\">",
   "author": "Astro",
   "dependencies": {
-    "sax": "~1.1.1",
-    "node-expat": "~2.3.0"
+    "sax": "~1.1.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
node-expat prevents npm installing in some machines cause c++ building..