### PR TITLE
serialize first

### DIFF
--- a/lib/Element.js
+++ b/lib/Element.js
@@ -14,7 +14,8 @@ function Element (name, attrs) {
   this.name = name
   this.parent = null
   this.children = []
-  this.setAttrs(attrs)
+  this.attrs = {}
+  if (attrs) this.setAttrs(attrs)
 }
 
 /* Accessors */
@@ -89,13 +90,19 @@ Element.prototype.getXmlns = function () {
 }
 
 Element.prototype.setAttrs = function (attrs) {
-  this.attrs = {}
-
   if (typeof attrs === 'string') {
     this.attrs.xmlns = attrs
-  } else if (attrs) {
-    Object.keys(attrs).forEach(function (key) {
-      this.attrs[key] = attrs[key]
+  } else if (typeof attrs === 'object' && attrs !== null) {
+    Object.keys(attrs).forEach(function (k) {
+      var key = k.toString()
+      var value = attrs[key]
+      if (value === undefined || value === null) {
+        return delete this.attrs[key]
+      }
+      if (typeof value.toString !== 'function') {
+        return
+      }
+      this.attrs[key] = value.toString()
     }, this)
   }
 }
@@ -306,10 +313,7 @@ Element.prototype.text = function (val) {
 }
 
 Element.prototype.attr = function (attr, val) {
-  if (typeof val !== 'undefined' || val === null) {
-    if (!this.attrs) {
-      this.attrs = {}
-    }
+  if (val !== undefined) {
     this.attrs[attr] = val
     return this
   }

--- a/test/element-test.js
+++ b/test/element-test.js
@@ -98,7 +98,7 @@ vows.describe('Element').addBatch({
       var e = new ltx.Element('e', { foo: 23, bar: 0, nil: null }).c('f').t(1000).up()
       assert.deepEqual(e.toJSON(), {
         name: 'e',
-        attrs: { foo: 23, bar: 0, nil: null },
+        attrs: { foo: 23, bar: 0 },
         children: [
           { name: 'f', attrs: {}, children: [1000] }
         ]


### PR DESCRIPTION
This is just an idea, feedback welcome.

UPDATE: I wanted to serialize first so that [equality](https://github.com/node-xmpp/ltx/pull/68) would be smarter with non string objects (JID for example :) ), but thinking twice equals should be the one serializing before comparing.

@lloydwatkin thoughts?

# WAT

* Allow setAttrs to be used to defined additional attrs instead of reseting attrs each time
* Always serialize attribute before setting them

# TO DO

* unit tests 