### PR TITLE
add support for es6 tagged templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ var escape = require('./lib/escape')
 var Element = require('./lib/Element')
 var equal = require('./lib/equal')
 var createElement = require('./lib/createElement')
+var tag = require('./lib/tag')
+
+exports = module.exports = tag
 
 exports.Element = Element
 
@@ -21,3 +24,5 @@ exports.escapeXMLText = escape.escapeXMLText
 
 exports.Parser = Parser
 exports.parse = parse
+
+exports.tag = tag

--- a/lib/tag.js
+++ b/lib/tag.js
@@ -1,0 +1,19 @@
+'use strict'
+
+var escape = require('./escape').escapeXML
+var parse = require('./parse')
+
+module.exports = function tag (/* [literals], ...substitutions */) {
+  var literals = arguments[0]
+  var substitutions = Array.prototype.slice.call(arguments, 1)
+
+  var str = ''
+
+  for (var i = 0; i < substitutions.length; i++) {
+    str += literals[i]
+    str += escape(substitutions[i])
+  }
+  str += literals[literals.length - 1]
+
+  return parse(str)
+}

--- a/test/tag-test.js
+++ b/test/tag-test.js
@@ -1,0 +1,23 @@
+'use strict'
+
+var vows = require('vows')
+var assert = require('assert')
+var ltx = require('..')
+var tag = require('../lib/tag')
+var Element = ltx.Element
+
+vows.describe('tag').addBatch({
+  'exported correctly': function () {
+    assert.equal(ltx, tag)
+    assert.equal(ltx.tag, tag)
+  },
+  'parses the string and return an Element object': function () {
+    // var r = tag`<foo>${'bar'}</foo>`
+    var r = tag(['<foo>', '</foo>'], 'bar')
+    assert(r instanceof Element)
+    var c = ltx.createElement('foo').t('bar')
+    assert(c.equals(r))
+    assert(r.equals(c))
+    assert.strictEqual(r.toString(), c.toString())
+  }
+}).export(module)


### PR DESCRIPTION
```javascript
import ltx from 'ltx'

const text = 'ltx is awesome'
const user = 'lloyd'
const domain = 'node-xmpp.org'

var stanza = ltx`
  <message type="chat" to="${user + '@' + domain}">
    <body>${text}</body>
  </message>
`
```

nice 'native' alternative to ltx JSX

I plan to add this to node-xmpp-stanza and es6 tagged templates support onto node-xmpp-jid once merged into ltx