### PR TITLE
Speedup xml escaping and unescaping

### DIFF
--- a/lib/escape.js
+++ b/lib/escape.js
@@ -1,33 +1,48 @@
 'use strict'
 
+var escapeXMLTable = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  '\'': '&apos;'
+}
+
+function escapeXMLReplace (match) {
+  return escapeXMLTable[match]
+}
+
+var unescapeXMLTable = {
+  '&amp;': '&',
+  '&#38;': '&',
+  '&lt;': '<',
+  '&#60;': '<',
+  '&gt;': '>',
+  '&#62;': '>',
+  '&quot;': '"',
+  '&#34;': '"',
+  '&apos;': "'",
+  '&#39;': "'"
+}
+
+function unescapeXMLReplace (match) {
+  return unescapeXMLTable[match]
+}
+
 exports.escapeXML = function escapeXML (s) {
-  return s
-    .replace(/\&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;')
+  return s.replace(/\&|<|>|"|'/g, escapeXMLReplace)
 }
 
 exports.unescapeXML = function unescapeXML (s) {
   return s
-    .replace(/\&(amp|#38);/g, '&')
-    .replace(/\&(lt|#60);/g, '<')
-    .replace(/\&(gt|#62);/g, '>')
-    .replace(/\&(quot|#34);/g, '"')
-    .replace(/\&(apos|#39);/g, "'")
+        .replace(/\&(amp|#38|lt|#60|gt|#62|quot|#34|apos|#39);/g, unescapeXMLReplace)
 }
 
 exports.escapeXMLText = function escapeXMLText (s) {
-  return s
-    .replace(/\&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
+  return s.replace(/\&|<|>/g, escapeXMLReplace)
 }
 
 exports.unescapeXMLText = function unescapeXMLText (s) {
   return s
-    .replace(/\&(amp|#38);/g, '&')
-    .replace(/\&(lt|#60);/g, '<')
-    .replace(/\&(gt|#62);/g, '>')
+    .replace(/\&(amp|#38|lt|#60|gt|#62);/g, unescapeXMLReplace)
 }


### PR DESCRIPTION
While profiling a server that uses ltx heavily, I noticed that XML escaping/unescaping took quite a lot of the processing time.  I looked for some optimizations and I've found something that yields quite a good improvement.  

Instead of using `.replace` multiple times with different regular expressions, combining the regular expression into a single `.replace` and using a replace function yields much higher throughput for replacement.

When I run the benchmarks, the serialize benchmark runs about 2x faster and the parse benchmark runs 33% faster.

I think the reason this works so well, is that escaping is the uncommon case.  Likely a string that required a lot of escaping or unescaping might be a bit slower, but overall this is a nice performance boost.