### PR TITLE
better JSON

### DIFF
--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -13,7 +13,7 @@ readdir(__dirname).forEach(function (file) {
     console.log(event.target.toString())
   })
   .on('complete', function () {
-    console.log('Fastest is ' + this.filter('fastest').map('name'))
+    console.log('Fastest is "' + this.filter('fastest').map('name') + '"')
   })
   .run({'async': false})
   console.log('\n')

--- a/benchmarks/json.js
+++ b/benchmarks/json.js
@@ -1,0 +1,48 @@
+'use strict'
+
+/*
+  benchmark JSON and compare with XML
+ */
+
+var benchmark = require('benchmark')
+var ltx = require('../index')
+var parse = ltx.parse
+var toJSON = ltx.toJSON
+var fromJSON = ltx.fromJSON
+
+var XML = [
+  '<message to="foo@bar" from="bar@foo" type="chat" id="foobar">',
+  '<body>Where there is love there is life.</body>',
+  '</message>'
+].join('')
+var el = parse(XML)
+var json = toJSON(el)
+var serializedjson = JSON.stringify(json)
+
+var suite = new benchmark.Suite('JSON')
+
+suite.add('from JSON', function () {
+  fromJSON(json)
+})
+
+suite.add('from serialized JSON', function () {
+  fromJSON(JSON.parse(serializedjson))
+})
+
+suite.add('from XML', function () {
+  parse(XML)
+})
+
+suite.add('to JSON', function () {
+  toJSON(el)
+})
+
+suite.add('to serialized JSON', function () {
+  JSON.stringify(toJSON(el))
+})
+
+suite.add('to XML', function () {
+  el.toString()
+})
+
+module.exports = suite

--- a/benchmarks/parsers.js
+++ b/benchmarks/parsers.js
@@ -1,5 +1,10 @@
 'use strict'
 
+/*
+  benchmark the parsing speed of the supported backends
+  difference with parse.js benchmark is that this doesn't use ltx at all
+ */
+
 var benchmark = require('benchmark')
 var node_xml = require('node-xml')
 var libxml = require('libxmljs')

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var Element = require('./lib/Element')
 var equal = require('./lib/equal')
 var createElement = require('./lib/createElement')
 var tag = require('./lib/tag')
+var json = require('./lib/json')
 
 exports = module.exports = tag
 
@@ -28,3 +29,6 @@ exports.Parser = Parser
 exports.parse = parse
 
 exports.tag = tag
+
+exports.toJSON = json.to
+exports.fromJSON = json.from

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -318,16 +318,6 @@ Element.prototype.toString = function () {
   return s
 }
 
-Element.prototype.toJSON = function () {
-  return {
-    name: this.name,
-    attrs: this.attrs,
-    children: this.children.map(function (child) {
-      return child && child.toJSON ? child.toJSON() : child
-    })
-  }
-}
-
 Element.prototype._addChildren = function (writer) {
   writer('>')
   for (var i = 0; i < this.children.length; i++) {

--- a/lib/json.js
+++ b/lib/json.js
@@ -1,0 +1,21 @@
+'use strict'
+
+var Element = require('./Element')
+
+module.exports.to = function to (el) {
+  return [
+    el.name,
+    el.attrs,
+    el.children.map(function (child) {
+      return typeof child === 'string' ? child : to(child)
+    })
+  ]
+}
+
+module.exports.from = function from (arr) {
+  var el = new Element(arr[0], arr[1])
+  arr[2].forEach(function (child) {
+    if (typeof child === 'string') el.t(el)
+    else el.cnode(from(child))
+  })
+}

--- a/lib/parsers/sax-js.js
+++ b/lib/parsers/sax-js.js
@@ -24,7 +24,6 @@ var SaxSaxjs = module.exports = function SaxSaxjs () {
   this.parser.onerror = function (e) {
     that.emit('error', e)
   }
-// TODO: other events, esp. entityDecl (billion laughs!)
 }
 
 inherits(SaxSaxjs, EventEmitter)

--- a/test/element-test.js
+++ b/test/element-test.js
@@ -82,16 +82,6 @@ vows.describe('Element').addBatch({
     'serialize with integer text': function () {
       var e = new Element('e').t(1000)
       assert.equal(e.getText(), 1000)
-    },
-    'serialize to json': function () {
-      var e = new Element('e', { foo: 23, bar: 0, nil: null }).c('f').t(1000).up()
-      assert.deepEqual(e.toJSON(), {
-        name: 'e',
-        attrs: { foo: 23, bar: 0, nil: null },
-        children: [
-          { name: 'f', attrs: {}, children: [1000] }
-        ]
-      })
     }
   },
   'remove': {

--- a/test/json.js
+++ b/test/json.js
@@ -1,0 +1,35 @@
+'use strict'
+
+var vows = require('vows')
+var assert = require('assert')
+var ltx = require('..')
+var Element = ltx.Element
+var toJSON = ltx.toJSON
+var fromJSON = ltx.fromJSON
+
+vows.describe('JSON').addBatch({
+  'toJSON': function () {
+    var e = new Element('e', {foo: 23, bar: 0, nil: null}).c('f').t(1000).up()
+    assert.deepEqual(toJSON(e), [
+      'e',
+      { foo: 23, bar: 0, nil: null },
+      [
+        ['f', {}, [1000]]
+      ]
+    ])
+  },
+  'fromJSON': function () {
+    var j = [
+      'e',
+      { foo: 23, bar: 0, nil: null },
+      [
+        ['f', {}, [1000]]
+      ]
+    ]
+    assert.equal(fromJSON(j).toString(), new Element('e', {foo: 23, bar: 0, nil: null}).c('f').t(1000).up().toString())
+  },
+  'JSON.stringify(element) returns serialized XML': function () {
+    var el = new Element('e', {'foo': 'bar'})
+    assert.equal(JSON.stringify(el), '<e foo="bar"/>')
+  }
+})


### PR DESCRIPTION
* moved `element.toJSON()` to `ltx.toJSON(el)`, the right default behavior is to have JSON.stringify use toString and serialize as XML
* added `ltx.fromJSON(obj)`, takes an object and return an Element
* changed JSON format from `{"name": "", "attrs": {}, "children": []}` to `[name, attrs, children]`

Also added a benchmark with interesting results:

```
suite JSON
from JSON x 782,744 ops/sec ±0.51% (91 runs sampled)
from serialized JSON x 330,672 ops/sec ±0.60% (95 runs sampled)
from XML x 87,593 ops/sec ±2.20% (88 runs sampled)
to JSON x 3,605,071 ops/sec ±0.28% (96 runs sampled)
to serialized JSON x 486,279 ops/sec ±1.52% (92 runs sampled)
to XML x 767,991 ops/sec ±0.88% (95 runs sampled)
```

I'm not sure what JSON use case was (XMPP-FTW and stanza.io maybe ? @lloydwatkin )and I was considering removing it but it proves useful for high throughput when the serializer and parser for a document are using ltx (WebWorker, Node.js cluster, ...). Altough this could still be moved to its own module ltx-json (probably better ?).