### PR TITLE
ltx.is

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,3 @@ addons:
     packages:
     - g++-4.8
     - gcc-4.8
-
-before_install:
-  - npm install -g browserify standard

--- a/README.md
+++ b/README.md
@@ -53,10 +53,6 @@ npm run benchmark
 ## Test
 
 ```
-npm install -g standard browserify
+npm install
 npm test
 ```
-
-## Licence
-
-MIT

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var Element = require('./lib/Element')
 var equal = require('./lib/equal')
 var createElement = require('./lib/createElement')
 var tag = require('./lib/tag')
+var is = require('./lib/is')
 
 exports = module.exports = tag
 
@@ -16,6 +17,10 @@ exports.equal = equal.equal
 exports.nameEqual = equal.name
 exports.attrsEqual = equal.attrs
 exports.childrenEqual = equal.children
+
+exports.isNode = is.isNode
+exports.isElement = is.isElement
+exports.isText = is.isText
 
 exports.createElement = createElement
 

--- a/lib/createElement.js
+++ b/lib/createElement.js
@@ -13,10 +13,9 @@ var Element = require('./Element')
 module.exports = function createElement (name, attrs /*, child1, child2, ...*/) {
   var el = new Element(name, attrs)
 
-  var children = Array.prototype.slice.call(arguments, 2)
+  for (var i = 2; i < arguments.length; i++) {
+    el.cnode(arguments[i])
+  }
 
-  children.forEach(function (child) {
-    el.cnode(child)
-  })
   return el
 }

--- a/lib/is.js
+++ b/lib/is.js
@@ -1,0 +1,15 @@
+'use strict'
+
+var Element = require('./Element')
+
+module.exports.isNode = function is (el) {
+  return el instanceof Element || typeof el === 'string'
+}
+
+module.exports.isElement = function isElement (el) {
+  return el instanceof Element
+}
+
+module.exports.isText = function isText (el) {
+  return typeof el === 'string'
+}

--- a/lib/tag.js
+++ b/lib/tag.js
@@ -5,13 +5,12 @@ var parse = require('./parse')
 
 module.exports = function tag (/* [literals], ...substitutions */) {
   var literals = arguments[0]
-  var substitutions = Array.prototype.slice.call(arguments, 1)
 
   var str = ''
 
-  for (var i = 0; i < substitutions.length; i++) {
-    str += literals[i]
-    str += escape(substitutions[i])
+  for (var i = 1; i < arguments.length; i++) {
+    str += literals[i - 1]
+    str += escape(arguments[i])
   }
   str += literals[literals.length - 1]
 

--- a/package.json
+++ b/package.json
@@ -6,18 +6,6 @@
   "repository": "github:node-xmpp/ltx",
   "homepage": "http://github.com/node-xmpp/ltx",
   "bugs": "http://github.com/node-xmpp/ltx/issues",
-  "maintainers": [
-    {
-      "name": "Astro",
-      "email": "astro@spaceboyz.net",
-      "web": "http://spaceboyz.net/~astro/"
-    },
-    {
-      "name": "Lloyd Watkin",
-      "email": "lloyd@evilprofessor.co.uk",
-      "web": "http://www.evilprofessor.co.uk"
-    }
-  ],
   "contributors": [
     "Stephan Maka",
     "Will Fife",
@@ -42,11 +30,13 @@
   },
   "devDependencies": {
     "benchmark": "^2.1.0",
+    "browserify": "^13.0.1",
     "libxmljs": "^0.18.0",
     "microtime": "^2.0.0",
     "node-expat": "^2.3.13",
     "node-xml": "^1.0.2",
     "sax": "^1.1.5",
+    "standard": "^7.1.2",
     "vows": "^0.8.1"
   }
 }

--- a/test/is-test.js
+++ b/test/is-test.js
@@ -1,0 +1,52 @@
+'use strict'
+
+var vows = require('vows')
+var assert = require('assert')
+var ltx = require('..')
+var is = require('../lib/is')
+var Element = ltx.Element
+
+vows.describe('isNode').addBatch({
+  'isNode': {
+    'exported correctly': function () {
+      assert.equal(ltx.isNode, is.isNode)
+    },
+    'returns true for Element': function () {
+      assert.strictEqual(is.isNode(new Element()), true)
+    },
+    'returns true for strings': function () {
+      assert.strictEqual(is.isNode('string'), true)
+    },
+    'returns false for anything else': function () {
+      [123, null, undefined, {}, [], true].forEach(function (value) {
+        assert.strictEqual(is.isNode(value), false)
+      })
+    }
+  },
+  'isElement': {
+    'exported correctly': function () {
+      assert.equal(ltx.isElement, is.isElement)
+    },
+    'returns true for Element': function () {
+      assert.strictEqual(is.isElement(new Element()), true)
+    },
+    'returns false for anything else': function () {
+      [123, null, undefined, {}, 'string', [], true].forEach(function (value) {
+        assert.strictEqual(is.isElement(value), false)
+      })
+    }
+  },
+  'isText': {
+    'exported correctly': function () {
+      assert.equal(ltx.isText, is.isText)
+    },
+    'returns true for strings': function () {
+      assert.strictEqual(is.isText('foo'), true)
+    },
+    'returns false for anything else': function () {
+      [123, null, undefined, {}, Element, [], true].forEach(function (value) {
+        assert.strictEqual(is.isText(value), false)
+      })
+    }
+  }
+}).export(module)

--- a/test/tag-test.js
+++ b/test/tag-test.js
@@ -15,7 +15,16 @@ vows.describe('tag').addBatch({
     // var r = tag`<foo>${'bar'}</foo>`
     var r = tag(['<foo>', '</foo>'], 'bar')
     assert(r instanceof Element)
-    var c = ltx.createElement('foo').t('bar')
+    var c = new Element('foo').t('bar')
+    assert(c.equals(r))
+    assert(r.equals(c))
+    assert.strictEqual(r.toString(), c.toString())
+  },
+  'multiple substitutions': function () {
+    // var r = tag`<foo a="${'b'}">${'bar'}</foo>`
+    var r = tag(['<foo a="', '">', '</foo>'], 'b', 'bar')
+    assert(r instanceof Element)
+    var c = new Element('foo', {a: 'b'}).t('bar')
     assert(c.equals(r))
     assert(r.equals(c))
     assert.strictEqual(r.toString(), c.toString())


### PR DESCRIPTION
this is useful for es6 and you want to check something is an instance of Element but also for a more functional approach 

```javascript
import ltx from 'ltx'

ltx.is(foo)
```

instead of 

```javascript
import ltx from 'ltx'
const Element = {ltx}

foo instanceof Element || foo === 'string'
```