### PR TITLE
Fix for comment tag if it contains some tag inside

### DIFF
--- a/lib/parsers/ltx.js
+++ b/lib/parsers/ltx.js
@@ -88,7 +88,11 @@ var SaxLtx = module.exports = function SaxLtx () {
           break
         case STATE_IGNORE_TAG:
           if (c === 62 /* > */) {
-            state = STATE_TEXT
+            var prev_first = data.charCodeAt(pos-1);
+            var prev_second = data.charCodeAt(pos-2);
+            if( prev_first === 45 /* - */ && prev_second === 45 /* - */){
+                state = STATE_TEXT
+            }
           }
           break
         case STATE_TAG:

--- a/lib/parsers/ltx.js
+++ b/lib/parsers/ltx.js
@@ -88,9 +88,9 @@ var SaxLtx = module.exports = function SaxLtx () {
           break
         case STATE_IGNORE_TAG:
           if (c === 62 /* > */) {
-            var prev_first = data.charCodeAt(pos-1);
-            var prev_second = data.charCodeAt(pos-2);
-            if( prev_first === 45 /* - */ && prev_second === 45 /* - */){
+            var prev_first = data.charCodeAt(pos-1)
+            var prev_second = data.charCodeAt(pos-2)
+            if( prev_first === 45 /* - */ && prev_second === 45 /* - */) {
                 state = STATE_TEXT
             }
           }


### PR DESCRIPTION
If a web.xml file contains a comment and comment contains some other tag, current logic of parsing is breaking as current logic only check that comment ends with >. 
e.g
<!-- 
   <tag1 arr1="val1"/>
-->
To handle this logic , created PR which tell comment end at -->.